### PR TITLE
Compare baseline results to current results by value instead of by pointer for byte blobs

### DIFF
--- a/test/regnative/unit.cpp
+++ b/test/regnative/unit.cpp
@@ -880,10 +880,7 @@ namespace
             values.push_back(pchName);
             values.push_back(pdwAttr);
             values.push_back(pdwCPlusTypeFlag);
-
-            // Due to how the "null" pointer is computed, only add when non-zero
-            if (pcchValue != 0)
-                values.push_back(HashByteArray(ppValue, pcchValue));
+            values.push_back(HashByteArray(ppValue, pcchValue));
             values.push_back(pcchValue);
         }
         return values;
@@ -1104,10 +1101,7 @@ namespace
             values.push_back(HashByteArray(ppvSigBlob, pcbSigBlob));
             values.push_back(pcbSigBlob);
             values.push_back(pdwCPlusTypeFlag);
-
-            // Due to how the "null" pointer is computed, only add when non-zero
-            if (pcchValue != 0)
-                values.push_back((size_t)ppValue);
+            values.push_back(HashByteArray(ppValue, pcchValue));
             values.push_back(pcchValue);
 
             if (sig != nullptr)


### PR DESCRIPTION
This will allow us to still use this same baseline/current testing methodology for our emit tests, where the baseline implementations move the data around on creation if they're in edit mode.