### PR TITLE
Disable fail-fast on strategy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest]
         flavor: [Debug, Release]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     name: Build (${{ matrix.os }}, ${{ matrix.flavor }})
     steps:


### PR DESCRIPTION
This allows us to see failures on all platforms isntead of cancelling jobs as soon as one leg fails (preventing us from seeing failures in other legs).