### PR TITLE
Update build infrastructure to install as a modern CMake package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,11 @@ jobs:
       run: |
         cmake -S external/dncp -B dncp-artifacts -DCMAKE_BUILD_TYPE=${{ matrix.flavor }}
         cmake --build dncp-artifacts --config ${{ matrix.flavor }} --target install
-        echo "CMAKE_PREFIX_PATH=${{ github.workspace }}/dncp-artifacts" >> $GITHUB_ENV
+
+    - name: Set CMake Module Path
+      if: ${{ !matrix.use-vendored-libs &&  matrix.os != 'windows-latest'}}
+      run: echo "CMAKE_PREFIX_PATH=${{ github.workspace }}/dncp-artifacts" >> $GITHUB_ENV
+      shell: bash
 
     - name: Build
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,14 +33,12 @@ jobs:
     - name: Build Vendored Dependencies
       if: ${{ !matrix.use-vendored-libs }}
       run: |
-        mkdir dncp-artifacts
         cmake -S external/dncp -B dncp-artifacts -DCMAKE_BUILD_TYPE=${{ matrix.flavor }}
         cmake --build dncp-artifacts --config ${{ matrix.flavor }} --target install
         echo "CMAKE_PREFIX_PATH=${{ github.workspace }}/dncp-artifacts" >> $GITHUB_ENV
 
     - name: Build
       run: |
-        mkdir artifacts
         cmake -S . -B artifacts -DCMAKE_BUILD_TYPE=${{ matrix.flavor }} -DINCLUDE_VENDORED_LIBS=${{ matrix.use-vendored-libs }}
         cmake --build artifacts --config ${{ matrix.flavor }} --target install
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         flavor: [Debug, Release]
+        use-vendored-libs: [true, false]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: Build (${{ matrix.os }}, ${{ matrix.flavor }})
@@ -28,11 +29,19 @@ jobs:
       with:
         dotnet-version: '7.0.x'
         include-prerelease: true
+    
+    - name: Build Vendored Dependencies
+      if: ${{ !matrix.use-vendored-libs }}
+      run: |
+        mkdir dncp-artifacts
+        cmake -S external/dncp -B dncp-artifacts -DCMAKE_BUILD_TYPE=${{ matrix.flavor }}
+        cmake --build dncp-artifacts --config ${{ matrix.flavor }} --target install
+        echo "CMAKE_PREFIX_PATH=${{ github.workspace }}/dncp-artifacts" >> $GITHUB_ENV
 
     - name: Build
       run: |
         mkdir artifacts
-        cmake -S . -B artifacts -DCMAKE_BUILD_TYPE=${{ matrix.flavor }}
+        cmake -S . -B artifacts -DCMAKE_BUILD_TYPE=${{ matrix.flavor }} -DINCLUDE_VENDORED_LIBS=${{ matrix.use-vendored-libs }}
         cmake --build artifacts --config ${{ matrix.flavor }} --target install
 
     - name: Build Managed Test Components

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         cmake --build dncp-artifacts --config ${{ matrix.flavor }} --target install
 
     - name: Set CMake Module Path
-      if: ${{ !matrix.use-vendored-libs &&  matrix.os != 'windows-latest'}}
+      if: ${{ !matrix.use-vendored-libs }}
       run: echo "CMAKE_PREFIX_PATH=${{ github.workspace }}/dncp-artifacts" >> $GITHUB_ENV
       shell: bash
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ else()
     find_package(dncp REQUIRED)
 endif()
 
+include_directories(src/inc)
+include_directories(src/inc/external) # Hiding the "external" subdirectory due to uses of <...> in cor.h.
+
 add_subdirectory(src/)
 add_subdirectory(test/)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,16 @@ cmake_minimum_required(VERSION 3.10)
 project(dnmd
     LANGUAGES C CXX)
 
+option(INCLUDE_VENDORED_LIBS "Include vendored libraries (submodules) instead of discovering dependencies through packages." ON)
+
 set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR})
+
+if (INCLUDE_VENDORED_LIBS)
+    add_subdirectory(external/dncp)
+else()
+    find_package(dncp REQUIRED)
+endif()
 
 add_subdirectory(src/)
 add_subdirectory(test/)
-add_subdirectory(external/dncp)
+

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
         <!-- Define the intermediate and output paths so the configuration isn't appended -->
         <IntermediateOutputPath>$(BaseIntermediateOutputPath)</IntermediateOutputPath>
         <OutputPath>$(BaseOutputPath)</OutputPath>
-        <NativeOutputPath>$(BaseArtifactsPath)/bin</NativeOutputPath>
+        <NativeOutputPath>$(BaseArtifactsPath)/lib</NativeOutputPath>
 
         <TargetFrameworkLatest>net7.0</TargetFrameworkLatest>
     </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,8 @@
         <!-- Define the intermediate and output paths so the configuration isn't appended -->
         <IntermediateOutputPath>$(BaseIntermediateOutputPath)</IntermediateOutputPath>
         <OutputPath>$(BaseOutputPath)</OutputPath>
-        <NativeOutputPath>$(BaseArtifactsPath)/lib</NativeOutputPath>
+        <NativeOutputPath Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(BaseArtifactsPath)/bin</NativeOutputPath>
+        <NativeOutputPath Condition="!$([MSBuild]::IsOSPlatform('Windows'))">$(BaseArtifactsPath)/lib</NativeOutputPath>
 
         <TargetFrameworkLatest>net7.0</TargetFrameworkLatest>
     </PropertyGroup>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,3 +6,15 @@ include_directories(BEFORE ./inc)
 add_subdirectory(dnmd/)
 add_subdirectory(interfaces/)
 add_subdirectory(mddump/)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/dnmd-config.cmake
+  INSTALL_DESTINATION lib/cmake/dnmd)
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/dnmd-config-version.cmake
+  VERSION 1.0.0
+  COMPATIBILITY SameMajorVersion )
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dnmd-config.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/dnmd-config-version.cmake
+        DESTINATION lib/cmake/dnmd)

--- a/src/config.cmake.in
+++ b/src/config.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/dnmdlib.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/dnmdinterfaces.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/dnmdinterfaces_static.cmake")
+
+check_required_components(dnmd)

--- a/src/dnmd/CMakeLists.txt
+++ b/src/dnmd/CMakeLists.txt
@@ -18,11 +18,24 @@ add_library(dnmd
   ${HEADERS}
 )
 
-target_include_directories(dnmd PUBLIC ../inc)
-target_include_directories(dnmd PUBLIC ../inc/external) # Hiding the "external" subdirectory due to uses of <...> in cor.h.
+add_library(dnmd::dnmd ALIAS dnmd)
+
+target_include_directories(dnmd PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../inc>)
+target_include_directories(dnmd PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../inc/external>) # Hiding the "external" subdirectory due to uses of <...> in cor.h.
+target_include_directories(dnmd INTERFACE $<INSTALL_INTERFACE:include>)
+
+if (NOT WIN32)
+  target_link_libraries(dnmd PUBLIC dncp::dncp dncp::winhdrs)
+endif()
 
 set_target_properties(dnmd PROPERTIES
-  PUBLIC_HEADER ../inc/dnmd.h
-  PUBLIC_HEADER ../inc/dnmd.hpp)
+  PUBLIC_HEADER "../inc/dnmd.h;../inc/dnmd.hpp")
 
-install(TARGETS dnmd)
+install(TARGETS dnmd EXPORT dnmd
+  PUBLIC_HEADER DESTINATION include
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
+
+install(EXPORT dnmd NAMESPACE dnmd:: FILE dnmdlib.cmake DESTINATION lib/cmake/dnmd)
+  

--- a/src/dnmd/CMakeLists.txt
+++ b/src/dnmd/CMakeLists.txt
@@ -20,13 +20,7 @@ add_library(dnmd
 
 add_library(dnmd::dnmd ALIAS dnmd)
 
-target_include_directories(dnmd PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../inc>)
-target_include_directories(dnmd PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../inc/external>) # Hiding the "external" subdirectory due to uses of <...> in cor.h.
-target_include_directories(dnmd INTERFACE $<INSTALL_INTERFACE:include>)
-
-if (NOT WIN32)
-  target_link_libraries(dnmd PUBLIC dncp::dncp dncp::winhdrs)
-endif()
+target_include_directories(dnmd PUBLIC $<INSTALL_INTERFACE:include>)
 
 set_target_properties(dnmd PROPERTIES
   PUBLIC_HEADER "../inc/dnmd.h;../inc/dnmd.hpp")

--- a/src/dnmd/entry.c
+++ b/src/dnmd/entry.c
@@ -281,7 +281,7 @@ static bool dump_table_rows(mdtable_t* table)
     }
 
     char const* str;
-    GUID guid;
+    md_guid_t guid;
     uint8_t const* blob;
     uint32_t blob_len;
     uint32_t constant;
@@ -312,11 +312,11 @@ static bool dump_table_rows(mdtable_t* table)
             {
                 IF_NOT_ONE_REPORT_RETURN(md_get_column_value_as_guid(cursor, IDX(j), 1, &guid));
                 printf("{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}|",
-                    guid.Data1, guid.Data2, guid.Data3,
-                    guid.Data4[0], guid.Data4[1],
-                    guid.Data4[2], guid.Data4[3],
-                    guid.Data4[4], guid.Data4[5],
-                    guid.Data4[6], guid.Data4[7]);
+                    guid.data1, guid.data2, guid.data3,
+                    guid.data4[0], guid.data4[1],
+                    guid.data4[2], guid.data4[3],
+                    guid.data4[4], guid.data4[5],
+                    guid.data4[6], guid.data4[7]);
             }
             else if (table->column_details[j] & mdtc_hblob)
             {

--- a/src/dnmd/internal.h
+++ b/src/dnmd/internal.h
@@ -6,16 +6,8 @@
 #include <stdbool.h>
 #include <assert.h>
 #include <string.h>
-
-// Reused Win32 data types
-typedef uint16_t WCHAR;
-typedef struct _GUID
-{
-    uint32_t Data1;
-    uint16_t Data2;
-    uint16_t Data3;
-    uint8_t  Data4[8];
-} GUID;
+#include <corhdr.h>
+#include <dnmd.h>
 
 // Implementations for missing bounds checking APIs.
 // See https://en.cppreference.com/w/c/error#Bounds_checking
@@ -23,9 +15,6 @@ typedef struct _GUID
 typedef size_t rsize_t;
 #endif // !__STDC_LIB_EXT1__
 
-#include <corhdr.h>
-
-#include <dnmd.h>
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(*a))
 

--- a/src/dnmd/internal.h
+++ b/src/dnmd/internal.h
@@ -163,7 +163,7 @@ bool try_get_blob(mdcxt_t* cxt, size_t offset, uint8_t const** blob, uint32_t* b
 bool validate_blob_heap(mdcxt_t* cxt);
 
 // GUID heap, #GUID - II.24.2.5
-bool try_get_guid(mdcxt_t* cxt, size_t idx, GUID* guid);
+bool try_get_guid(mdcxt_t* cxt, size_t idx, md_guid_t* guid);
 bool validate_guid_heap(mdcxt_t* cxt);
 
 // Table heap, #~ - II.24.2.6

--- a/src/dnmd/query.c
+++ b/src/dnmd/query.c
@@ -491,7 +491,7 @@ int32_t md_get_column_value_as_blob(mdcursor_t c, col_index_t col_idx, uint32_t 
     return read_in;
 }
 
-int32_t md_get_column_value_as_guid(mdcursor_t c, col_index_t col_idx, uint32_t out_length, GUID* guid)
+int32_t md_get_column_value_as_guid(mdcursor_t c, col_index_t col_idx, uint32_t out_length, md_guid_t* guid)
 {
     if (out_length == 0)
         return 0;

--- a/src/dnmd/streams.c
+++ b/src/dnmd/streams.c
@@ -52,7 +52,7 @@ bool try_get_user_string(mdcxt_t* cxt, size_t offset, mduserstring_t* str, size_
         // There is an additional terminal byte which holds a 1 or 0.
         // The 1 signifies Unicode characters that require handling beyond
         // that normally provided for 8-bit encoding sets.
-        str->str = (WCHAR const*)begin;
+        str->str = (char16_t const*)begin;
         str->str_bytes = byte_count;
         str->final_byte = begin[byte_count - 1];
     }
@@ -111,12 +111,12 @@ bool validate_blob_heap(mdcxt_t* cxt)
     return true;
 }
 
-bool try_get_guid(mdcxt_t* cxt, size_t idx, GUID* guid)
+bool try_get_guid(mdcxt_t* cxt, size_t idx, md_guid_t* guid)
 {
     assert(cxt != NULL && guid != NULL);
 
     mdstream_t* h = &cxt->guid_heap;
-    size_t count = h->size / sizeof(GUID);
+    size_t count = h->size / sizeof(md_guid_t);
 
     if (count < idx)
         return false;
@@ -130,7 +130,7 @@ bool try_get_guid(mdcxt_t* cxt, size_t idx, GUID* guid)
         return true;
     }
 
-    GUID* guids = (GUID*)h->ptr;
+    md_guid_t* guids = (md_guid_t*)h->ptr;
     *guid = guids[idx - 1];
     return true;
 }
@@ -140,7 +140,7 @@ bool validate_guid_heap(mdcxt_t* cxt)
     assert(cxt != NULL);
 
     mdstream_t* h = &cxt->guid_heap;
-    if (h->size % sizeof(GUID) != 0)
+    if (h->size % sizeof(md_guid_t) != 0)
         return false;
 
     return true;

--- a/src/inc/dnmd.h
+++ b/src/inc/dnmd.h
@@ -8,8 +8,8 @@
 #if defined(__has_include)
 #if __has_include(<uchar.h>)
 #include <uchar.h>
-#else
-// When uchar.h isn't available, define char16_t as per the C standard.
+#elif !defined(__cplusplus)
+// When uchar.h isn't available and we're in C, define char16_t as per the C standard.
 typedef uint_least16_t char16_t;
 #endif
 

--- a/src/inc/dnmd.h
+++ b/src/inc/dnmd.h
@@ -1,10 +1,25 @@
 #ifndef _SRC_INC_DNMD_H_
 #define _SRC_INC_DNMD_H_
 
+#include <stdint.h>
+#include <stddef.h>
+
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+
+#ifdef _WIN32
+#include <windef.h>
+#include <guiddef.h>
+#else
+#include <dncp.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+typedef uint32_t mdToken;                // Generic token
 typedef void* mdhandle_t;
 
 // Create a metadata handle that can be used to parse the supplied metadata.

--- a/src/inc/dnmd.h
+++ b/src/inc/dnmd.h
@@ -6,20 +6,22 @@
 
 #ifndef __cplusplus
 #include <stdbool.h>
-#endif
-
-#ifdef _WIN32
-#include <guiddef.h>
-typedef wchar_t WCHAR;
-#else
-#include <dncp.h>
+#include <uchar.h>
 #endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef uint32_t mdToken;                // Generic token
+typedef uint32_t mdToken;
+
+typedef struct md_guid_t {
+    uint32_t data1;
+    uint16_t data2;
+    uint16_t data3;
+    uint8_t  data4[8];
+} md_guid_t;
+
 typedef void* mdhandle_t;
 
 // Create a metadata handle that can be used to parse the supplied metadata.
@@ -135,7 +137,7 @@ typedef intptr_t mduserstringcursor_t;
 
 typedef struct _mduserstring_t
 {
-    WCHAR const* str;
+    char16_t const* str;
     uint32_t str_bytes;
     uint8_t final_byte;
 } mduserstring_t;
@@ -416,7 +418,7 @@ int32_t md_get_column_value_as_constant(mdcursor_t c, col_index_t col_idx, uint3
 int32_t md_get_column_value_as_utf8(mdcursor_t c, col_index_t col_idx, uint32_t out_length, char const** str);
 int32_t md_get_column_value_as_userstring(mdcursor_t c, col_index_t col_idx, uint32_t out_length, mduserstring_t* strings);
 int32_t md_get_column_value_as_blob(mdcursor_t c, col_index_t col_idx, uint32_t out_length, uint8_t const** blob, uint32_t* blob_len);
-int32_t md_get_column_value_as_guid(mdcursor_t c,col_index_t col_idx, uint32_t out_length, GUID* guid);
+int32_t md_get_column_value_as_guid(mdcursor_t c,col_index_t col_idx, uint32_t out_length, md_guid_t* guid);
 
 // Find a row or range of rows where the supplied column has the expected value.
 // These APIs assume the value to look for is the value in the table, typically record IDs (RID)

--- a/src/inc/dnmd.h
+++ b/src/inc/dnmd.h
@@ -5,8 +5,18 @@
 #include <stddef.h>
 
 #ifndef __cplusplus
+
 #include <stdbool.h>
+// MacOS doesn't have uchar.h
+#if defined(__has_include)
+#if __has_include(<uchar.h>)
 #include <uchar.h>
+#else
+// When uchar.h isn't available, define char16_t as per the C standard.
+typedef uint_least16_t char16_t;
+#endif
+#endif
+
 #endif
 
 #ifdef __cplusplus

--- a/src/inc/dnmd.h
+++ b/src/inc/dnmd.h
@@ -9,8 +9,8 @@
 #endif
 
 #ifdef _WIN32
-#include <windef.h>
 #include <guiddef.h>
+typedef wchar_t WCHAR;
 #else
 #include <dncp.h>
 #endif

--- a/src/inc/dnmd.h
+++ b/src/inc/dnmd.h
@@ -3,9 +3,6 @@
 
 #include <stdint.h>
 #include <stddef.h>
-
-#ifndef __cplusplus
-
 #include <stdbool.h>
 // MacOS doesn't have uchar.h
 #if defined(__has_include)
@@ -14,7 +11,6 @@
 #else
 // When uchar.h isn't available, define char16_t as per the C standard.
 typedef uint_least16_t char16_t;
-#endif
 #endif
 
 #endif

--- a/src/inc/dnmd.hpp
+++ b/src/inc/dnmd.hpp
@@ -17,18 +17,4 @@ struct mdhandle_deleter_t
 // C++ lifetime wrapper for mdhandle_t type
 using mdhandle_ptr = std::unique_ptr<mdhandle_t, mdhandle_deleter_t>;
 
-template<typename T>
-struct malloc_deleter_t
-{
-    using pointer = T*;
-    void operator()(T* mem)
-    {
-        ::free((void*)mem);
-    }
-};
-
-// C++ lifetime wrapper for malloc'd memory
-template<typename T>
-using malloc_ptr = std::unique_ptr<T, malloc_deleter_t<T>>;
-
 #endif // _SRC_INC_DNMD_HPP_

--- a/src/inc/dnmd.hpp
+++ b/src/inc/dnmd.hpp
@@ -3,7 +3,6 @@
 
 #include "dnmd.h"
 #include <memory>
-#include <cstdlib>
 
 struct mdhandle_deleter_t
 {

--- a/src/inc/internal/dnmd_platform.hpp
+++ b/src/inc/internal/dnmd_platform.hpp
@@ -13,10 +13,26 @@
 
 #endif // !BUILD_WINDOWS
 
+#include <cstdlib>
+
 #include <dncp.h>
 #include <cor.h>
 #include <dnmd.hpp>
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(*a))
+
+template<typename T>
+struct malloc_deleter_t
+{
+    using pointer = T*;
+    void operator()(T* mem)
+    {
+        ::free((void*)mem);
+    }
+};
+
+// C++ lifetime wrapper for malloc'd memory
+template<typename T>
+using malloc_ptr = std::unique_ptr<T, malloc_deleter_t<T>>;
 
 #endif // _SRC_INC_INTERNAL_DNMD_PLATFORM_HPP_

--- a/src/interfaces/CMakeLists.txt
+++ b/src/interfaces/CMakeLists.txt
@@ -35,8 +35,8 @@ add_library(dnmd_interfaces
 set_target_properties(dnmd_interfaces PROPERTIES EXPORT_NAME interfaces)
 add_library(dnmd::interfaces ALIAS dnmd_interfaces)
 
-target_include_directories(dnmd_interfaces_static PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../inc> $<INSTALL_INTERFACE:include>)
-target_include_directories(dnmd_interfaces PRIVATE ../inc)
+target_include_directories(dnmd_interfaces_static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../inc> $<INSTALL_INTERFACE:include>)
+target_include_directories(dnmd_interfaces PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../inc> $<INSTALL_INTERFACE:include>)
 
 target_compile_definitions(dnmd_interfaces PRIVATE DNMD_BUILD_SHARED)
 
@@ -45,13 +45,13 @@ target_link_libraries(dnmd_interfaces_static
   dnmd::dnmd
   dncp::dncp)
 target_link_libraries(dnmd_interfaces
-  PUBLIC
+  PRIVATE
   dnmd::dnmd
   dncp::dncp)
 
 if(NOT MSVC)
   target_link_libraries(dnmd_interfaces_static PUBLIC dncp::winhdrs)
-  target_link_libraries(dnmd_interfaces PUBLIC dncp::winhdrs)
+  target_link_libraries(dnmd_interfaces PRIVATE dncp::winhdrs)
 endif()
 
 if (NOT WIN32)
@@ -69,9 +69,6 @@ if (NOT WIN32)
   target_link_libraries(dnmd_interfaces_static PUBLIC ${ICU_TARGET_NAME})
   target_link_libraries(dnmd_interfaces PRIVATE ${ICU_TARGET_NAME})
 endif()
-
-set_target_properties(dnmd_interfaces_static PROPERTIES
-  PUBLIC_HEADER ../inc/dnmd_interfaces.hpp)
 
 set_target_properties(dnmd_interfaces PROPERTIES
   PUBLIC_HEADER ../inc/dnmd_interfaces.hpp

--- a/src/interfaces/CMakeLists.txt
+++ b/src/interfaces/CMakeLists.txt
@@ -46,8 +46,13 @@ target_link_libraries(dnmd_interfaces_static
   dncp::dncp)
 target_link_libraries(dnmd_interfaces
   PRIVATE
-  dnmd::dnmd
   dncp::dncp)
+
+# Link dnmd publicly when building in the repo to get the correct include paths set up
+# for downstream targets in the project that use the internal headers.
+target_link_libraries(dnmd_interfaces
+  PUBLIC
+  $<BUILD_INTERFACE:dnmd::dnmd>)
 
 if(NOT MSVC)
   target_link_libraries(dnmd_interfaces_static PUBLIC dncp::winhdrs)

--- a/src/interfaces/CMakeLists.txt
+++ b/src/interfaces/CMakeLists.txt
@@ -22,35 +22,51 @@ add_library(dnmd_interfaces_static
   ${HEADERS}
 )
 
+set_target_properties(dnmd_interfaces_static PROPERTIES EXPORT_NAME interfaces_static)
+
+add_library(dnmd::interfaces_static ALIAS dnmd_interfaces_static)
+
 add_library(dnmd_interfaces
   SHARED
   ${SOURCES}
   ${HEADERS}
 )
 
-target_include_directories(dnmd_interfaces_static PUBLIC ../inc)
+set_target_properties(dnmd_interfaces PROPERTIES EXPORT_NAME interfaces)
+add_library(dnmd::interfaces ALIAS dnmd_interfaces)
+
+target_include_directories(dnmd_interfaces_static PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../inc> $<INSTALL_INTERFACE:include>)
 target_include_directories(dnmd_interfaces PRIVATE ../inc)
 
 target_compile_definitions(dnmd_interfaces PRIVATE DNMD_BUILD_SHARED)
 
 target_link_libraries(dnmd_interfaces_static
+  PUBLIC
   dnmd
   dncp)
 target_link_libraries(dnmd_interfaces
+  PUBLIC
   dnmd
   dncp)
 
 if(NOT MSVC)
-  target_link_libraries(dnmd_interfaces_static dncp::winhdrs)
-  target_link_libraries(dnmd_interfaces dncp::winhdrs)
+  target_link_libraries(dnmd_interfaces_static PUBLIC dncp::winhdrs)
+  target_link_libraries(dnmd_interfaces PUBLIC dncp::winhdrs)
 endif()
 
-if(APPLE)
-  # Use ICU when running on macOS
-  target_link_libraries(dnmd_interfaces icucore)
-elseif(UNIX)
-  # Use ICU when running on Linux
-  target_link_libraries(dnmd_interfaces icuuc)
+if (NOT WIN32)
+  # Use ICU when running on macOS or Linux
+  if (APPLE)
+    set(ICU_FIND_COMPONENTS core)
+    set(ICU_FIND_REQUIRED_core TRUE)
+    set(ICU_TARGET_NAME ICU::core)
+  elseif(UNIX)
+    set(ICU_FIND_COMPONENTS uc)
+    set(ICU_FIND_REQUIRED_uc TRUE)
+    set(ICU_TARGET_NAME ICU::uc)
+  endif()
+  include(FindICU)
+  target_link_libraries(dnmd_interfaces PUBLIC ${ICU_TARGET_NAME})
 endif()
 
 set_target_properties(dnmd_interfaces_static PROPERTIES
@@ -59,7 +75,18 @@ set_target_properties(dnmd_interfaces_static PROPERTIES
 set_target_properties(dnmd_interfaces PROPERTIES
   PUBLIC_HEADER ../inc/dnmd_interfaces.hpp
   INTERPROCEDURAL_OPTIMIZATION $<$<NOT:$<CONFIG:DEBUG>>:TRUE>)
+  
+install(TARGETS dnmd_interfaces_static EXPORT interfaces_static
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib)
 
-install(TARGETS dnmd_interfaces_static)
-install(TARGETS dnmd_interfaces
-  DESTINATION bin)
+install(EXPORT interfaces_static NAMESPACE dnmd:: FILE dnmdinterfaces_static.cmake DESTINATION lib/cmake/dnmd)
+
+install(TARGETS dnmd_interfaces EXPORT interfaces
+  PUBLIC_HEADER DESTINATION include
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
+
+install(EXPORT interfaces NAMESPACE dnmd:: FILE dnmdinterfaces.cmake DESTINATION lib/cmake/dnmd)
+  

--- a/src/interfaces/CMakeLists.txt
+++ b/src/interfaces/CMakeLists.txt
@@ -42,12 +42,12 @@ target_compile_definitions(dnmd_interfaces PRIVATE DNMD_BUILD_SHARED)
 
 target_link_libraries(dnmd_interfaces_static
   PUBLIC
-  dnmd
-  dncp)
+  dnmd::dnmd
+  dncp::dncp)
 target_link_libraries(dnmd_interfaces
   PUBLIC
-  dnmd
-  dncp)
+  dnmd::dnmd
+  dncp::dncp)
 
 if(NOT MSVC)
   target_link_libraries(dnmd_interfaces_static PUBLIC dncp::winhdrs)

--- a/src/interfaces/CMakeLists.txt
+++ b/src/interfaces/CMakeLists.txt
@@ -35,8 +35,8 @@ add_library(dnmd_interfaces
 set_target_properties(dnmd_interfaces PROPERTIES EXPORT_NAME interfaces)
 add_library(dnmd::interfaces ALIAS dnmd_interfaces)
 
-target_include_directories(dnmd_interfaces_static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../inc> $<INSTALL_INTERFACE:include>)
-target_include_directories(dnmd_interfaces PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../inc> $<INSTALL_INTERFACE:include>)
+target_include_directories(dnmd_interfaces_static PUBLIC $<INSTALL_INTERFACE:include>)
+target_include_directories(dnmd_interfaces PUBLIC $<INSTALL_INTERFACE:include>)
 
 target_compile_definitions(dnmd_interfaces PRIVATE DNMD_BUILD_SHARED)
 
@@ -44,15 +44,11 @@ target_link_libraries(dnmd_interfaces_static
   PUBLIC
   dnmd::dnmd
   dncp::dncp)
+
 target_link_libraries(dnmd_interfaces
   PRIVATE
-  dncp::dncp)
-
-# Link dnmd publicly when building in the repo to get the correct include paths set up
-# for downstream targets in the project that use the internal headers.
-target_link_libraries(dnmd_interfaces
-  PUBLIC
-  $<BUILD_INTERFACE:dnmd::dnmd>)
+  dncp::dncp
+  dnmd::dnmd)
 
 if(NOT MSVC)
   target_link_libraries(dnmd_interfaces_static PUBLIC dncp::winhdrs)

--- a/src/interfaces/metadataimport.cpp
+++ b/src/interfaces/metadataimport.cpp
@@ -566,7 +566,7 @@ HRESULT STDMETHODCALLTYPE MetadataImportRO::GetScopeProps(
         return CLDB_E_INDEX_NOTFOUND;
 
     GUID mvid;
-    if (1 != md_get_column_value_as_guid(cursor, mdtModule_Mvid, 1, &mvid))
+    if (1 != md_get_column_value_as_guid(cursor, mdtModule_Mvid, 1, reinterpret_cast<md_guid_t*>(&mvid)))
         return CLDB_E_FILE_CORRUPT;
     *pmvid = mvid;
 

--- a/src/mddump/CMakeLists.txt
+++ b/src/mddump/CMakeLists.txt
@@ -7,8 +7,8 @@ add_executable(mddump
 )
 
 target_link_libraries(mddump
-  dnmd
-  dncp)
+  dnmd::dnmd
+  dncp::dncp)
 
 if(NOT MSVC)
   target_link_libraries(mddump dncp::winhdrs)

--- a/test/regnative/CMakeLists.txt
+++ b/test/regnative/CMakeLists.txt
@@ -9,12 +9,12 @@ add_library(regnative
 )
 
 target_link_libraries(regnative
-  dnmd_interfaces
-  dncp)
+  dnmd::interfaces
+  dncp::dncp)
 
 if(NOT MSVC)
   target_link_libraries(regnative dncp::winhdrs)
 endif()
 
 install(TARGETS regnative
-  DESTINATION bin)
+  DESTINATION lib)

--- a/test/regnative/CMakeLists.txt
+++ b/test/regnative/CMakeLists.txt
@@ -17,4 +17,6 @@ if(NOT MSVC)
 endif()
 
 install(TARGETS regnative
-  DESTINATION lib)
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)


### PR DESCRIPTION
This PR updates the build of DNMD in a few ways:

- Export the dnmd targets as package components.
- Ensure that dncp is consumed through its exported interface in all targets
- Consume icu through CMake modules instead of direct linking
- Update dnmd.h to be buildable without including any other headers (useful for prototyping using dnmd in Mono)
  - Add a dependency on dncp from dnmd itself to complete the above.