### PR TITLE
Implement save APIs and provide an mdmerge tool that composes an image from deltas and writes it to disk instead of dumping to console.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,9 +3,10 @@ include(../configure.cmake)
 
 include_directories(BEFORE ./inc)
 
-add_subdirectory(dnmd/)
-add_subdirectory(interfaces/)
-add_subdirectory(mddump/)
+add_subdirectory(dnmd)
+add_subdirectory(interfaces)
+add_subdirectory(mddump)
+add_subdirectory(mdmerge)
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(config.cmake.in

--- a/src/dnmd/entry.c
+++ b/src/dnmd/entry.c
@@ -613,6 +613,8 @@ bool md_write_to_buffer(mdhandle_t handle, uint8_t* buffer, size_t* len)
     size_t image_size = get_image_size(cxt);
     size_t const full_buffer_len = *len;
 
+    // Handle the case where no edits have occurred.
+    // This operation is basically a "copy to new buffer".
     if (cxt->editor == NULL)
     {
         if (buffer == NULL || full_buffer_len < cxt->raw_metadata.size)

--- a/src/dnmd/entry.c
+++ b/src/dnmd/entry.c
@@ -481,6 +481,7 @@ void free_mdmem(mdcxt_t* cxt, void* mem)
 
 static size_t get_stream_header_and_contents_size(char const* heap_name, size_t heap_size)
 {
+    assert(heap_name != NULL);
     // II.24.2.2 Stream header
     size_t const base_stream_header_size =
         sizeof(uint32_t) // Offset
@@ -489,6 +490,7 @@ static size_t get_stream_header_and_contents_size(char const* heap_name, size_t 
     ;
 
     // Add the size of the stream header
+    // II.24.2.2 Stream name is padded to a 4-byte boundary
     size_t save_size = base_stream_header_size;
     save_size += align_to((uint32_t)strlen(heap_name) + 1, 4);
     // Add the size of the stream itself.
@@ -509,8 +511,8 @@ static size_t get_table_stream_size(mdcxt_t* cxt)
         + sizeof(uint8_t) // MinorVersion
         + sizeof(uint8_t) // HeapSizes
         + sizeof(uint8_t) // Reserved
-        + sizeof(uint64_t) // Valid
-        + sizeof(uint64_t) // Sorted
+        + sizeof(uint64_t) // Valid tables
+        + sizeof(uint64_t) // Sorted tables
         // Rows and Tables entries are both variable length and calculated below
     ;
     
@@ -548,7 +550,6 @@ size_t md_get_save_size(mdhandle_t handle)
         + sizeof(uint16_t) // Flags
         + sizeof(uint16_t) // Streams (number of streams)
     ;
-
     
     size_t save_size = image_header_size;
 
@@ -654,7 +655,7 @@ bool md_save(mdhandle_t handle, uint8_t* buffer, size_t buffer_len, size_t* cons
     if (cxt->user_string_heap.size != 0)
         stream_count++;
 
-    const char* tables_stream_name = "#~";
+    char const* tables_stream_name = "#~";
 
     if (cxt->context_flags & mdc_minimal_delta)
     {

--- a/src/dnmd/entry.c
+++ b/src/dnmd/entry.c
@@ -478,3 +478,369 @@ void free_mdmem(mdcxt_t* cxt, void* mem)
     // Now that we aren't tracking the memory, free it.
     free(m);
 }
+
+static size_t get_stream_header_and_contents_size(char const* heap_name, size_t heap_size)
+{
+    // II.24.2.2 Stream header
+    size_t const base_stream_header_size =
+        sizeof(uint32_t) // Offset
+        + sizeof(uint32_t) // Size
+        // Name is variable length and calculated below
+    ;
+
+    // Add the size of the stream header
+    size_t save_size = base_stream_header_size;
+    save_size += align_to((uint32_t)strlen(heap_name) + 1, 4);
+    // Add the size of the stream itself.
+    // It's not placed directly after the header in the image,
+    // but we might as well account for it here while we're checking
+    // the heap's existence.
+    save_size += heap_size;
+
+    return save_size;
+}
+
+static size_t get_table_stream_size(mdcxt_t* cxt)
+{
+    // II.24.2.6 #~ stream
+    size_t const table_stream_header_size =        
+        + sizeof(uint32_t) // Reserved
+        + sizeof(uint8_t) // MajorVersion
+        + sizeof(uint8_t) // MinorVersion
+        + sizeof(uint8_t) // HeapSizes
+        + sizeof(uint8_t) // Reserved
+        + sizeof(uint64_t) // Valid
+        + sizeof(uint64_t) // Sorted
+        // Rows and Tables entries are both variable length and calculated below
+    ;
+    
+    size_t save_size = table_stream_header_size;
+    
+    for (uint8_t i = 0; i < MDTABLE_MAX_COUNT; ++i)
+    {
+        if (cxt->tables[i].cxt != NULL && cxt->tables[i].row_count != 0)
+        {
+            save_size += sizeof(uint32_t); // Row count
+            save_size += cxt->tables[i].data.size; // Table data
+        }
+    }
+    
+    return save_size;
+}
+
+size_t md_get_save_size(mdhandle_t handle)
+{
+    mdcxt_t* cxt = extract_mdcxt(handle);
+    if (cxt == NULL)
+        return 0;
+    
+    if (cxt->editor == NULL)
+        return cxt->raw_metadata.size;
+    
+    // II.24.2.1 Metadata Root size
+    size_t const image_header_size =
+        sizeof(uint32_t) // Signature
+        + sizeof(uint16_t) // MajorVersion
+        + sizeof(uint16_t) // MinorVersion
+        + sizeof(uint32_t) // Reserved
+        + sizeof(uint32_t) // Length (of version string)
+        + align_to((uint32_t)strlen(cxt->version) + 1, 4) // Version String
+        + sizeof(uint16_t) // Flags
+        + sizeof(uint16_t) // Streams (number of streams)
+    ;
+
+    
+    size_t save_size = image_header_size;
+
+    if (cxt->blob_heap.size != 0)
+        save_size += get_stream_header_and_contents_size("#Blob", cxt->blob_heap.size);
+    if (cxt->guid_heap.size != 0)
+        save_size += get_stream_header_and_contents_size("#GUID", cxt->guid_heap.size);
+    if (cxt->strings_heap.size != 0)
+        save_size += get_stream_header_and_contents_size("#Strings", align_to((uint32_t)cxt->strings_heap.size, 4));
+    if (cxt->user_string_heap.size != 0)
+        save_size += get_stream_header_and_contents_size("#US", cxt->user_string_heap.size);
+
+    if (cxt->context_flags & mdc_minimal_delta)
+        save_size += get_stream_header_and_contents_size("#JTD", 0);
+    
+    // All names of the tables stream are the same length,
+    // so pick the one in the standard.
+    save_size += get_stream_header_and_contents_size("#~", get_table_stream_size(cxt));
+
+    return save_size;
+}
+
+// II.24.2.2 Stream header
+static bool write_stream_header(char const* name, size_t size, uint32_t** offset_space, uint8_t** buffer, size_t* buffer_len)
+{
+    size_t name_len = strlen(name);
+    size_t name_buf_len = align_to((uint32_t)name_len + 1, 4);
+
+    *offset_space = (uint32_t*)*buffer;
+
+    if (!advance_stream(buffer, buffer_len, 4) // Offset
+        || !write_u32(buffer, buffer_len, (uint32_t)size)) // Size
+    {
+        return false;
+    }
+
+    if (*buffer_len < name_buf_len)
+        return false;
+
+    // Name
+    memcpy(*buffer, name, name_len + 1);
+    advance_stream(buffer, buffer_len, name_len + 1);
+    // Pad the name to a 4-byte boundary.
+    advance_stream(buffer, buffer_len, name_buf_len - name_len - 1);
+
+    return true;
+}
+
+bool md_save(mdhandle_t handle, uint8_t* buffer, size_t buffer_len, size_t* consumed_buffer_len)
+{
+    mdcxt_t* cxt = extract_mdcxt(handle);
+    if (cxt == NULL)
+        return false;
+
+    if (cxt->editor == NULL)
+    {
+        if (buffer_len < cxt->raw_metadata.size)
+            return false;
+        memcpy(buffer, cxt->raw_metadata.ptr, cxt->raw_metadata.size);
+        return true;
+    }
+
+    uint8_t* const buffer_start = buffer;
+    size_t const full_buffer_len = buffer_len;
+    size_t remaining_buffer_len = buffer_len;
+    if (!write_u32(&buffer, &remaining_buffer_len, METADATA_SIG)
+        || !write_u16(&buffer, &remaining_buffer_len, cxt->major_ver)
+        || !write_u16(&buffer, &remaining_buffer_len, cxt->minor_ver)
+        || !write_u32(&buffer, &remaining_buffer_len, 0))
+    {
+        return false;
+    }
+    
+    size_t version_str_len = strlen(cxt->version);
+    uint32_t version_buf_len = align_to((uint32_t)version_str_len + 1, 4);
+
+    if (!write_u32(&buffer, &remaining_buffer_len, (uint32_t)version_str_len + 1))
+        return false;
+    
+    if (remaining_buffer_len < version_buf_len)
+        return false;
+    
+    memcpy(buffer, cxt->version, version_str_len + 1);
+    // Pad the version string to a 4-byte boundary.
+    memset(buffer + version_str_len + 1, 0, version_buf_len - version_str_len - 1);
+    advance_stream(&buffer, &remaining_buffer_len, version_buf_len);
+
+    if (!write_u16(&buffer, &remaining_buffer_len, cxt->flags))
+        return false;
+    
+    uint16_t stream_count = 0;
+    if (cxt->blob_heap.size != 0)
+        stream_count++;
+    if (cxt->guid_heap.size != 0)
+        stream_count++;
+    if (cxt->strings_heap.size != 0)
+        stream_count++;
+    if (cxt->user_string_heap.size != 0)
+        stream_count++;
+
+    const char* tables_stream_name = "#~";
+
+    if (cxt->context_flags & mdc_minimal_delta)
+    {
+        tables_stream_name = "#-";
+        stream_count++;
+    }
+
+    uint64_t valid_tables = 0;
+    uint64_t sorted_tables = 0;
+    for (uint8_t i = 0; i < MDTABLE_MAX_COUNT; ++i)
+    {
+        if (cxt->tables[i].cxt != NULL && cxt->tables[i].row_count != 0)
+        {
+            // We don't support saving if we are in the process of adding a new row.
+            if (cxt->tables[i].is_adding_new_row)
+                return false;
+
+            valid_tables |= (1ULL << i);
+            if (cxt->tables[i].is_sorted)
+                sorted_tables |= (1ULL << i);
+            
+            // Indirect tables only exist in images that use the uncompresed stream.
+            if (table_is_indirect_table((mdtable_id_t)i))
+                tables_stream_name = "#-";
+        }
+    }
+
+    // The tables stream is always included.
+    stream_count++;
+    
+    if (!write_u16(&buffer, &remaining_buffer_len, stream_count))
+        return false;
+
+    uint32_t* blob_heap_offset_space = NULL;
+    uint32_t* strings_heap_offset_space = NULL;
+    uint32_t* guid_heap_offset_space = NULL;
+    uint32_t* user_string_heap_offset_space = NULL;
+    uint32_t* tables_heap_offset_space = NULL;
+#ifdef DNMD_PORTABLE_PDB
+    uint32_t* pdb_offset_space = NULL;
+#endif
+
+    // Write the stream headers.
+    if (cxt->context_flags & mdc_minimal_delta)
+    {
+        uint32_t* offset_space;
+        if (!write_stream_header("#JTD", 0, &offset_space, &buffer, &remaining_buffer_len))
+            return false;
+        
+        // Set the stream offset to the location of the stream header.
+        // There's no content in this stream, but the offset must be valid.
+        *offset_space = (uint32_t)((uint8_t*)offset_space - buffer_start);
+    }
+
+    if (cxt->strings_heap.size != 0)
+    {
+        // The strings heap should be aligned to 4 bytes.
+        if (!write_stream_header("#Strings", align_to((uint32_t)cxt->strings_heap.size, 4), &strings_heap_offset_space, &buffer, &remaining_buffer_len))
+            return false;
+    }
+
+    if (cxt->blob_heap.size != 0)
+    {
+        if (!write_stream_header("#Blob", cxt->blob_heap.size, &blob_heap_offset_space, &buffer, &remaining_buffer_len))
+            return false;
+    }
+
+    if (cxt->guid_heap.size != 0)
+    {
+        if (!write_stream_header("#GUID", cxt->guid_heap.size, &guid_heap_offset_space, &buffer, &remaining_buffer_len))
+            return false;
+    }
+
+    if (cxt->user_string_heap.size != 0)
+    {
+        if (!write_stream_header("#US", cxt->user_string_heap.size, &user_string_heap_offset_space, &buffer, &remaining_buffer_len))
+            return false;
+    }
+
+#ifdef DNMD_PORTABLE_PDB
+    if (cxt->pdb.size != 0)
+    {
+        if (!write_stream_header("#Pdb", cxt->pdb.size, &pdb_offset_space, &buffer, &remaining_buffer_len))
+            return false;
+    }
+#endif // DNMD_PORTABLE_PDB
+
+    size_t table_stream_size = get_table_stream_size(cxt);
+
+    if (table_stream_size > UINT32_MAX)
+        return false;
+
+    if (!write_stream_header(tables_stream_name, (uint32_t)table_stream_size, &tables_heap_offset_space, &buffer, &remaining_buffer_len))
+        return false;
+
+    // Write the stream data
+    if (cxt->strings_heap.size != 0)
+    {
+        assert(strings_heap_offset_space != NULL);
+        *strings_heap_offset_space = (uint32_t)(buffer - buffer_start);
+        uint32_t string_heap_size = align_to((uint32_t)cxt->strings_heap.size, 4);
+        if (remaining_buffer_len < string_heap_size)
+            return false;
+        memcpy(buffer, cxt->strings_heap.ptr, cxt->strings_heap.size);
+        memset((uint8_t*)buffer + cxt->strings_heap.size, 0, string_heap_size - cxt->strings_heap.size);
+        advance_stream(&buffer, &remaining_buffer_len, string_heap_size);
+    }
+
+    if (cxt->blob_heap.size != 0)
+    {
+        assert(blob_heap_offset_space != NULL);
+        *blob_heap_offset_space = (uint32_t)(buffer - buffer_start);
+        if (remaining_buffer_len < cxt->blob_heap.size)
+            return false;
+        memcpy(buffer, cxt->blob_heap.ptr, cxt->blob_heap.size);
+        advance_stream(&buffer, &remaining_buffer_len, cxt->blob_heap.size);
+    }
+
+    if (cxt->guid_heap.size != 0)
+    {
+        assert(guid_heap_offset_space != NULL);
+        *guid_heap_offset_space = (uint32_t)(buffer - buffer_start);
+        if (remaining_buffer_len < cxt->guid_heap.size)
+            return false;
+        memcpy(buffer, cxt->guid_heap.ptr, cxt->guid_heap.size);
+        advance_stream(&buffer, &remaining_buffer_len, cxt->guid_heap.size);
+    }
+
+    if (cxt->user_string_heap.size != 0)
+    {
+        assert(user_string_heap_offset_space != NULL);
+        *user_string_heap_offset_space = (uint32_t)(buffer - buffer_start);
+        if (remaining_buffer_len < cxt->user_string_heap.size)
+            return false;
+        memcpy(buffer, cxt->user_string_heap.ptr, cxt->user_string_heap.size);
+        advance_stream(&buffer, &remaining_buffer_len, cxt->user_string_heap.size);
+    }
+
+#ifdef DNMD_PORTABLE_PDB
+    if (cxt->pdb.size != 0)
+    {
+        assert(pdb_offset_space != NULL);
+        *pdb_offset_space = (uint32_t)(buffer - buffer_start);
+        if (remaining_buffer_len < cxt->pdb.size)
+            return false;
+        memcpy(buffer, cxt->pdb.ptr, cxt->pdb.size);
+        advance_stream(&buffer, &remaining_buffer_len, cxt->pdb.size);
+    }
+#endif // DNMD_PORTABLE_PDB
+
+    if (remaining_buffer_len < table_stream_size)
+        return false;
+
+    // Always write the table stream header. This is required for a valid image.
+    assert(tables_heap_offset_space != NULL);
+    *tables_heap_offset_space = (uint32_t)(buffer - buffer_start);
+    if (!write_u32(&buffer, &remaining_buffer_len, 0) // Reserved
+        || !write_u8(&buffer, &remaining_buffer_len, 2) // MajorVersion
+        || !write_u8(&buffer, &remaining_buffer_len, 0) // MinorVersion
+        || !write_u8(&buffer, &remaining_buffer_len, (uint8_t)(cxt->context_flags & mdc_image_flags & ~mdc_extra_data)) // HeapOffsetSizes, excluding the extra data flag as we don't save it to write out.
+        || !write_u8(&buffer, &remaining_buffer_len, 1) // Reserved
+        || !write_u64(&buffer, &remaining_buffer_len, valid_tables)
+        || !write_u64(&buffer, &remaining_buffer_len, sorted_tables))
+    {
+        return false;
+    }
+
+    if (valid_tables != 0)
+    {
+        for (uint8_t i = 0; i < MDTABLE_MAX_COUNT; ++i)
+        {
+            if (valid_tables & (1ULL << i))
+            {
+                if (!write_u32(&buffer, &remaining_buffer_len, cxt->tables[i].row_count))
+                    return false;
+            }
+        }
+
+        for (uint8_t i = 0; i < MDTABLE_MAX_COUNT; ++i)
+        {
+            if (valid_tables & (1ULL << i))
+            {
+                assert (remaining_buffer_len >= cxt->tables[i].data.size);
+                memcpy(buffer, cxt->tables[i].data.ptr, cxt->tables[i].data.size);
+                advance_stream(&buffer, &remaining_buffer_len, cxt->tables[i].data.size);
+            }
+        }
+    }
+
+    *consumed_buffer_len = (full_buffer_len - remaining_buffer_len);
+
+    assert(*consumed_buffer_len == md_get_save_size(handle));
+    return true;
+}

--- a/src/dnmd/streams.c
+++ b/src/dnmd/streams.c
@@ -268,7 +268,7 @@ bool validate_tables(mdcxt_t* cxt)
     (void)cxt;
     // [TODO] Reference ECMA-335 and encode table verification.
     // [TODO] Validate that tables marked as sorted are actually sorted.
-    // [TODO] Do not allow the EncMap and *Ptr tables to be present in a compressed table heap.
+    // [TODO] Do not allow the *Ptr tables to be present in a compressed table heap.
     return true;
 }
 

--- a/src/inc/dnmd.h
+++ b/src/inc/dnmd.h
@@ -514,6 +514,9 @@ void md_commit_row_add(mdcursor_t row);
 // Add a user string to the #US heap.
 mduserstringcursor_t md_add_userstring_to_heap(mdhandle_t handle, char16_t const* userstring);
 
+size_t md_get_save_size(mdhandle_t handle);
+
+bool md_save(mdhandle_t handle, uint8_t* buffer, size_t buffer_len, size_t* consumed_buffer_len);
 #ifdef __cplusplus
 }
 #endif

--- a/src/inc/dnmd.h
+++ b/src/inc/dnmd.h
@@ -514,9 +514,7 @@ void md_commit_row_add(mdcursor_t row);
 // Add a user string to the #US heap.
 mduserstringcursor_t md_add_userstring_to_heap(mdhandle_t handle, char16_t const* userstring);
 
-size_t md_get_save_size(mdhandle_t handle);
-
-bool md_save(mdhandle_t handle, uint8_t* buffer, size_t buffer_len, size_t* consumed_buffer_len);
+bool md_write_to_buffer(mdhandle_t handle, uint8_t* buffer, size_t* len);
 #ifdef __cplusplus
 }
 #endif

--- a/src/mdmerge/CMakeLists.txt
+++ b/src/mdmerge/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(SOURCES
+  main.cpp
+)
+
+add_executable(mdmerge
+  ${SOURCES}
+)
+
+target_link_libraries(mdmerge
+  dnmd::dnmd
+  dncp::dncp)
+
+if(NOT MSVC)
+  target_link_libraries(mdmerge dncp::winhdrs)
+endif()
+
+install(TARGETS mdmerge)

--- a/src/mdmerge/main.cpp
+++ b/src/mdmerge/main.cpp
@@ -187,10 +187,10 @@ void merge(merge_config_t cfg)
         std::fprintf(stderr, "invalid metadata!\n");
     }
 
-    size_t save_size = md_get_save_size(handle.get());
+    size_t save_size;
+    md_write_to_buffer(handle.get(), nullptr, &save_size);
     malloc_span<uint8_t> out_buffer { (uint8_t*)malloc(save_size), save_size };
-    size_t consumed_size;
-    if (!md_save(handle.get(), out_buffer, out_buffer.size(), &consumed_size))
+    if (!md_write_to_buffer(handle.get(), out_buffer, &save_size))
     {
         std::fprintf(stderr, "Failed to save image.\n");
     }

--- a/src/mdmerge/main.cpp
+++ b/src/mdmerge/main.cpp
@@ -110,6 +110,7 @@ template<typename T>
 using malloc_span = owning_span<T, free_deleter>;
 
 bool read_in_file(char const* file, malloc_span<uint8_t>& b);
+bool write_out_file(char const* file, malloc_span<uint8_t> b);
 bool get_metadata_from_pe(malloc_span<uint8_t>& b);
 bool get_metadata_from_file(malloc_span<uint8_t>& b);
 
@@ -126,6 +127,7 @@ bool apply_deltas(mdhandle_t handle, std::vector<char const*>& deltas, std::vect
 {
     for (char const* p : deltas)
     {
+        std::printf("Reading in delta image '%s'.\n", p);
         malloc_span<uint8_t> d;
         if (!read_in_file(p, d) || !get_metadata_from_file(d))
         {
@@ -143,25 +145,24 @@ bool apply_deltas(mdhandle_t handle, std::vector<char const*>& deltas, std::vect
     return true;
 }
 
-struct dump_config_t
+struct merge_config_t
 {
-    dump_config_t()
+    merge_config_t()
         : path{}
         , delta_paths{}
         , data{}
-        , table_id{ -1 }
     { }
 
-    dump_config_t(dump_config_t const& other) = delete;
-    dump_config_t(dump_config_t&& other) = default;
+    merge_config_t(merge_config_t const& other) = delete;
+    merge_config_t(merge_config_t&& other) = default;
 
     char const* path;
+    char const* output_path;
     std::vector<char const*> delta_paths;
     std::vector<malloc_span<uint8_t>> data;
-    int32_t table_id;
 };
 
-void dump(dump_config_t cfg)
+void merge(merge_config_t cfg)
 {
     malloc_span<uint8_t> b;
     if (!read_in_file(cfg.path, b))
@@ -177,20 +178,32 @@ void dump(dump_config_t cfg)
     }
 
     std::printf("Loaded '%s'.\n    Metadata blob size %zu bytes\n", cfg.path, b.size());
-    if (cfg.table_id != -1)
-        std::printf("    Reading in table %d (0x%x)\n", cfg.table_id, cfg.table_id);
 
     mdhandle_ptr handle;
     if (!create_mdhandle(b, handle)
         || !apply_deltas(handle.get(), cfg.delta_paths, cfg.data)
-        || !md_validate(handle.get())
-        || !md_dump_tables(handle.get(), cfg.table_id))
+        || !md_validate(handle.get()))
     {
         std::fprintf(stderr, "invalid metadata!\n");
     }
+
+    size_t save_size = md_get_save_size(handle.get());
+    malloc_span<uint8_t> out_buffer { (uint8_t*)malloc(save_size), save_size };
+    size_t consumed_size;
+    if (!md_save(handle.get(), out_buffer, out_buffer.size(), &consumed_size))
+    {
+        std::fprintf(stderr, "Failed to save image.\n");
+    }
+
+    if (!write_out_file(cfg.output_path, std::move(out_buffer)))
+    {
+        std::fprintf(stderr, "Failed to write out '%s'\n", cfg.output_path);
+        return;
+    }
+    std::printf("Wrote out '%s'.\n", cfg.output_path);
 }
 
-static char const* s_usage = "Syntax: mddump [-t <table_id>]? [-d <path_to_delta>]* <path ecma-335 data>";
+static char const* s_usage = "Syntax: mddump [-o <output_path>] [-d <path_to_delta>]* <path ecma-335 data>";
 
 int main(int ac, char** av)
 {
@@ -200,7 +213,7 @@ int main(int ac, char** av)
         return EXIT_FAILURE;
     }
 
-    dump_config_t cfg;
+    merge_config_t cfg;
 
     // Process arguments
     span<char*> args{ &av[1], (size_t)ac - 1 };
@@ -218,21 +231,15 @@ int main(int ac, char** av)
         {
             switch (arg[1])
             {
-            case 't':
+            case 'o':
             {
                 i++;
                 if (i >= args.size())
                 {
-                    std::fprintf(stderr, "Missing table ID.\n");
+                    std::fprintf(stderr, "Missing output file path.\n");
                     return EXIT_FAILURE;
                 }
-
-                cfg.table_id = (int32_t)::strtoul(args[i], nullptr, 0);
-                if ((errno == ERANGE) || cfg.table_id >= 64)
-                {
-                    std::fprintf(stderr, "Invalid table ID: '%s'. Must be [0, 64)\n", args[i]);
-                    return EXIT_FAILURE;
-                }
+                cfg.output_path = args[i];
                 continue;
             }
             case 'd':
@@ -259,7 +266,7 @@ int main(int ac, char** av)
         return EXIT_FAILURE;
     }
 
-    dump(std::move(cfg));
+    merge(std::move(cfg));
 
     return EXIT_SUCCESS;
 }
@@ -313,6 +320,17 @@ bool read_in_file(char const* file, malloc_span<uint8_t>& b)
 
     b = { (uint8_t*)std::malloc(size), size };
     fd.read((char*)(uint8_t*)b, b.size());
+    return true;
+}
+
+bool write_out_file(char const* file, malloc_span<uint8_t> b)
+{
+    // Read in the entire file
+    std::ofstream fd{ file, std::ios::binary | std::ios::out };
+    if (!fd)
+        return false;
+
+    fd.write((char*)(uint8_t*)b, b.size());
     return true;
 }
 

--- a/src/mdmerge/main.cpp
+++ b/src/mdmerge/main.cpp
@@ -203,7 +203,7 @@ void merge(merge_config_t cfg)
     std::printf("Wrote out '%s'.\n", cfg.output_path);
 }
 
-static char const* s_usage = "Syntax: mddump [-o <output_path>] [-d <path_to_delta>]* <path ecma-335 data>";
+static char const* s_usage = "Syntax: mdmerge [-o <output_path>] [-d <path_to_delta>]* <path ecma-335 data>";
 
 int main(int ac, char** av)
 {


### PR DESCRIPTION
With these APIs, we can now implement writing an image out to disk or into memory.

The mdmerge tool produces a raw metadata file, not a PE-enveloped file. As a result, mddump (in this repo) is one of the few decent tools that can read it.

The work to fully construct a composite delta image in a PE envelope that can be run requires additional work. For example, including valid RVAs is difficult and requires a more comprehensive implementation and CLI interface, so I deferred on this work as it would likely be as complex if not moreso than the actual metadata saving logic.

Most of the code in mdmerge is a direct copy of mddump. 