### PR TITLE
Fix refcount leaks in dnmd::interfaces

### DIFF
--- a/src/interfaces/dispenser.cpp
+++ b/src/interfaces/dispenser.cpp
@@ -79,7 +79,10 @@ namespace
 
             mdhandle_ptr md_ptr{ mdhandle };
 
-            dncp::com_ptr<ControllingIUnknown> obj { new (std::nothrow) ControllingIUnknown() };
+            dncp::com_ptr<ControllingIUnknown> obj;
+            // ControllingIUnknown's constructor assumes that we start with 1 ref. dncp::com_ptr always calls AddRef when created with a pointer,
+            // but not when assigned the underlying pointer in this manner.
+            obj.p = new (std::nothrow) ControllingIUnknown();
             if (obj == nullptr)
                 return E_OUTOFMEMORY;
 

--- a/src/interfaces/dispenser.cpp
+++ b/src/interfaces/dispenser.cpp
@@ -80,9 +80,7 @@ namespace
             mdhandle_ptr md_ptr{ mdhandle };
 
             dncp::com_ptr<ControllingIUnknown> obj;
-            // ControllingIUnknown's constructor assumes that we start with 1 ref. dncp::com_ptr always calls AddRef when created with a pointer,
-            // but not when assigned the underlying pointer in this manner.
-            obj.p = new (std::nothrow) ControllingIUnknown();
+            obj.Attach(new (std::nothrow) ControllingIUnknown());
             if (obj == nullptr)
                 return E_OUTOFMEMORY;
 

--- a/src/interfaces/dnmdowner.hpp
+++ b/src/interfaces/dnmdowner.hpp
@@ -22,18 +22,20 @@ struct IDNMDOwner : IUnknown
 // We use a reference wrapper around the handle to allow the handle to be swapped out.
 // We plan to use swapping to implement table sorting as DNMD itself does not support
 // sorting tables or remapping tokens.
+// This is explitly a non-owning view as this view will be passed to other tear-offs of the same object,
+// which would otherwise lead to memory leaks.
 class mdhandle_view final
 {
 private:
-    dncp::com_ptr<IDNMDOwner> _owner;
+    IDNMDOwner* _owner;
 public:
-    mdhandle_view(dncp::com_ptr<IDNMDOwner> owner)
-        : _owner{ owner.p }
+    mdhandle_view(IDNMDOwner* owner)
+        : _owner{ owner }
     {
     }
 
     mdhandle_view(mdhandle_view const& other)
-        : _owner{ other._owner.p }
+        : _owner{ other._owner }
     {
     }
 
@@ -41,7 +43,7 @@ public:
 
     mdhandle_view& operator=(mdhandle_view const& other)
     {
-        _owner = dncp::com_ptr<IDNMDOwner>{ other._owner.p };
+        _owner = other._owner;
         return *this;
     }
 


### PR DESCRIPTION
The new mdhandle_view type and the tear-off mechanism in combination with dncp::com_ptr's refcounting semantics lead to use leaking one refcount and creating a self-referential refcount cycle. This PR fixes both and ensures we don't leak.