### PR TITLE
Move md_get_pdb_id to dnmd_pdb.h and reduce CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,34 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
-        flavor: [Debug, Release]
-        use-vendored-libs: [true, false]
+        include:
+          # Ubuntu: Debug and Release, both vendored modes
+          - os: ubuntu-latest
+            flavor: Debug
+            use-vendored-libs: true
+          - os: ubuntu-latest
+            flavor: Debug
+            use-vendored-libs: false
+          - os: ubuntu-latest
+            flavor: Release
+            use-vendored-libs: true
+          - os: ubuntu-latest
+            flavor: Release
+            use-vendored-libs: false
+          # macOS: Debug vendored, Release non-vendored
+          - os: macos-latest
+            flavor: Debug
+            use-vendored-libs: true
+          - os: macos-latest
+            flavor: Release
+            use-vendored-libs: false
+          # Windows: Release vendored, Debug non-vendored
+          - os: windows-latest
+            flavor: Release
+            use-vendored-libs: true
+          - os: windows-latest
+            flavor: Debug
+            use-vendored-libs: false
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: Build (${{ matrix.os }}, ${{ matrix.flavor }}, Single Build = ${{ matrix.use-vendored-libs }})
@@ -28,7 +53,7 @@ jobs:
     - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '8.0.x'
-    
+
     - name: List dotnet information
       run: dotnet --info
 

--- a/src/dnmd/entry.c
+++ b/src/dnmd/entry.c
@@ -743,11 +743,16 @@ bool md_get_pdb_id(mdhandle_t handle, size_t* pdb_id_len, uint8_t* pdb_id)
     if (!try_get_pdb(cxt, &pdb))
         return false;
 
-    if (!pdb_id_len || *pdb_id_len < ARRAY_SIZE(pdb.pdb_id))
+    if (!pdb_id_len)
         return false;
 
+    size_t input_len = *pdb_id_len;
     *pdb_id_len = ARRAY_SIZE(pdb.pdb_id);
-    memcpy(pdb_id, pdb.pdb_id, *pdb_id_len);
+
+    if (input_len < ARRAY_SIZE(pdb.pdb_id))
+        return false;
+
+    memcpy(pdb_id, pdb.pdb_id, ARRAY_SIZE(pdb.pdb_id));
     return true;
 }
 #endif

--- a/src/inc/dnmd.h
+++ b/src/inc/dnmd.h
@@ -68,13 +68,6 @@ bool md_dump_tables(mdhandle_t handle, int32_t table_id);
 
 char const* md_get_version_string(mdhandle_t handle);
 
-#ifdef DNMD_PORTABLE_PDB
-// Get the PDB ID from the #Pdb stream of a Portable PDB.
-// The pdb_id_len parameter is an in/out parameter. The caller should set the initial value to the size of the supplied buffer.
-// Returns false if the handle does not contain a #Pdb stream.
-bool md_get_pdb_id(mdhandle_t handle, size_t* pdb_id_len, uint8_t* pdb_id);
-#endif
-
 //
 // All tables possible in ECMA-335
 //

--- a/src/inc/dnmd_pdb.h
+++ b/src/inc/dnmd_pdb.h
@@ -12,6 +12,12 @@
 extern "C" {
 #endif
 
+// Get the PDB ID from the #Pdb stream of a Portable PDB.
+// The pdb_id_len parameter is an in/out parameter. The caller should set the initial value to the size of the supplied buffer.
+// Will set *pdb_id_len to the required buffer size if the supplied buffer is too small.
+// Returns false if the handle does not contain a #Pdb stream or if the supplied buffer is too small to hold the PDB ID.
+bool md_get_pdb_id(mdhandle_t handle, size_t* pdb_id_len, uint8_t* pdb_id);
+
 // Methods to parse specialized blob formats defined in the Portable PDB spec.
 // https://github.com/dotnet/runtime/blob/main/docs/design/specs/PortablePdb-Metadata.md
 


### PR DESCRIPTION
## Changes

### Move md_get_pdb_id to dnmd_pdb.h and fix size query pattern
- Move the `md_get_pdb_id` declaration from `dnmd.h` to `dnmd_pdb.h` where it belongs alongside other Portable PDB APIs.
- Fix the implementation to always write back the required buffer size before checking if the caller's buffer is large enough, enabling callers to query the needed size with a too-small buffer.

### Reduce CI matrix to sparse configuration
Replace the full 12-leg matrix (3 OS × 2 flavors × 2 vendored) with a sparse 8-leg matrix to reduce CI costs while maintaining coverage:
- **Ubuntu**: Debug and Release, both vendored modes (4 legs)
- **macOS**: Debug vendored, Release non-vendored (2 legs)
- **Windows**: Release vendored, Debug non-vendored (2 legs)
- **Sanitizers**: unchanged (Ubuntu Debug)